### PR TITLE
Configure Dependabot pour les dépendances pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Cette PR ajoute le fichier **.github/dependabot.yml** pour activer le scan quotidien des dépendances Python (pip) et générer automatiquement des PR de mise à jour de sécurité.