### PR TITLE
docs: add stop and restart commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Pour configurer et lancer le **backend REST** de CrewAI Studio :
    ```bash
   squadmanager studio serve
    ```
+8. Arrêter l'interface locale de CrewAI Studio :
+   ```bash
+  squadmanager studio stop
+   ```
+9. Redémarrer l'interface locale de CrewAI Studio :
+   ```bash
+  squadmanager studio restart
+   ```
 
 ## Running the Project
 


### PR DESCRIPTION
Documentation des commandes `stop` et `restart` pour l'UI locale dans le README.